### PR TITLE
Fixes bug: dashes converted to 0 in file name

### DIFF
--- a/src/vcsparser.core/git/GitLogParser.cs
+++ b/src/vcsparser.core/git/GitLogParser.cs
@@ -111,10 +111,10 @@ namespace vcsparser.core.git
 
         private void ParseStatsLine(GitLogParserContext context, String line)
         {
-            String[] stats = line.Replace('-', '0').Split('\t');
+            String[] stats = line.Split('\t');
             FileChanges file = new FileChanges();
-            file.Added = Convert.ToInt32(stats[0]);
-            file.Deleted = Convert.ToInt32(stats[1]);
+            file.Added = Convert.ToInt32(stats[0].Replace('-', '0'));
+            file.Deleted = Convert.ToInt32(stats[1].Replace('-', '0'));
             file.FileName = ProcessRenames(context, stats[2]);
             context.CurrentCommit.FileChanges.Add(file);
         }

--- a/src/vcsparser.unittests/Resources/GitExample2.txt
+++ b/src/vcsparser.unittests/Resources/GitExample2.txt
@@ -6,4 +6,4 @@ CommitDate: 2018-09-19T14:19:14+01:00
 
     Commit message 1
 
--	-	src/dir1/File1.cs
+-	-	src/dir-with-dashes/File1.cs

--- a/src/vcsparser.unittests/git/GivenAGitLogParser.cs
+++ b/src/vcsparser.unittests/git/GivenAGitLogParser.cs
@@ -108,6 +108,7 @@ namespace vcsparser.unittests.git
 
             GitCommit commit = this.parser.Parse(stream)[0];
             Assert.Single(commit.FileChanges);
+            Assert.Equal("src/dir-with-dashes/File1.cs", commit.FileChanges[0].FileName);
             Assert.Equal(0, commit.FileChanges[0].Added);
             Assert.Equal(0, commit.FileChanges[0].Deleted);
         }


### PR DESCRIPTION
When parsing stats should not convert "-" to "0" in file name