### PR TITLE
Bugdatabase process cache fix for same changeset id

### DIFF
--- a/src/vcsparser.core/ChangesetProcessor.cs
+++ b/src/vcsparser.core/ChangesetProcessor.cs
@@ -17,8 +17,8 @@ namespace vcsparser.core
 
         private Dictionary<string, string> renameCache = new Dictionary<string, string>();
 
-        private Dictionary<string, WorkItem> workItemCache = new Dictionary<string, WorkItem>();
-        public Dictionary<string, WorkItem> WorkItemCache {
+        private Dictionary<string, List<WorkItem>> workItemCache = new Dictionary<string, List<WorkItem>>();
+        public Dictionary<string, List<WorkItem>> WorkItemCache {
             get { return workItemCache; }
         }
 

--- a/src/vcsparser.core/IChangesetProcessor.cs
+++ b/src/vcsparser.core/IChangesetProcessor.cs
@@ -10,7 +10,7 @@ namespace vcsparser.core
     public interface IChangesetProcessor
     {
         Dictionary<DateTime, Dictionary<string, DailyCodeChurn>> Output { get; }
-        Dictionary<string, WorkItem> WorkItemCache { get; }
+        Dictionary<string, List<WorkItem>> WorkItemCache { get; }
         int ChangesetsWithBugs { get; }
 
         void ProcessChangeset(IChangeset changeset);

--- a/src/vcsparser.core/bugdatabase/BugDatabaseProcessor.cs
+++ b/src/vcsparser.core/bugdatabase/BugDatabaseProcessor.cs
@@ -51,7 +51,10 @@ namespace vcsparser.core.bugdatabase
                 var workItemList = workItemParser.ParseFile(file.FileName);
                 foreach(var workitem in workItemList)
                 {
-                    changesetProcessor.WorkItemCache.Add(workitem.ChangesetId, workitem);
+                    if (!changesetProcessor.WorkItemCache.ContainsKey(workitem.ChangesetId))
+                        changesetProcessor.WorkItemCache.Add(workitem.ChangesetId, new List<WorkItem>());
+
+                    changesetProcessor.WorkItemCache[workitem.ChangesetId].Add(workitem);
                 }
             }
         }

--- a/src/vcsparser.unittests/GivenAChangesetProcessor.cs
+++ b/src/vcsparser.unittests/GivenAChangesetProcessor.cs
@@ -211,7 +211,7 @@ namespace vcsparser.unittests
         public void WhenProcessingBugDatabaseChangesetAndMatchesBugRegexesShouldIncrementBugDatabaseCodeChurn()
         {
             this.changesetProcessor = new ChangesetProcessor(@"gramolias+;bug+", this.loggerMock.Object);
-            this.changesetProcessor.WorkItemCache.Add("SomeCommitHash", new WorkItem());
+            this.changesetProcessor.WorkItemCache.Add("SomeCommitHash", new List<WorkItem>());
 
             var c = CreateCommitWithAddedLines("file2", 10);
             c.ChangesetFileChanges[0].Deleted = 5;
@@ -226,7 +226,7 @@ namespace vcsparser.unittests
         public void WhenProcessingBugDatabaseChangesetAndDoesntMatchBugRegexesThatDoesntMatchShouldIncrementBugDatabaseCodeChurn()
         {
             this.changesetProcessor = new ChangesetProcessor(@"gramolias+;bug+", this.loggerMock.Object);
-            this.changesetProcessor.WorkItemCache.Add("SomeCommitHash", new WorkItem());
+            this.changesetProcessor.WorkItemCache.Add("SomeCommitHash", new List<WorkItem>());
 
             var c = CreateCommitWithAddedLines("file2", 10);
             c.ChangesetFileChanges[0].Deleted = 5;
@@ -241,7 +241,7 @@ namespace vcsparser.unittests
         public void WhenProcessingBugDatabaseChangesetAndDailyCodeChurnContainsBugDatabaseThenAppenedExisting()
         {
             this.changesetProcessor = new ChangesetProcessor(@"gramolias+;bug+", this.loggerMock.Object);
-            this.changesetProcessor.WorkItemCache.Add("SomeCommitHash", new WorkItem());
+            this.changesetProcessor.WorkItemCache.Add("SomeCommitHash", new List<WorkItem>());
 
             var c1 = CreateCommitWithAddedLines("file2", 10);
             c1.ChangesetFileChanges[0].Deleted = 5;


### PR DESCRIPTION
fixes #27 

Process cache now creates a list of work items in case there are multiple work items with the same change set id