### PR TITLE
Removes try/catch that is throws odd message

### DIFF
--- a/src/vcsparser.bugdatabase.azuredevops.unittests/GivenAAzureDevOps.cs
+++ b/src/vcsparser.bugdatabase.azuredevops.unittests/GivenAAzureDevOps.cs
@@ -130,37 +130,6 @@ namespace vcsparser.bugdatabase.azuredevops.unittests
         }
 
         [Fact]
-        public void WhenProcessWorkItemWithItemAndExcptionThenReturnSingleWorkItem()
-        {
-            this.requestMock.Setup(r => r.GetWorkItemList()).Returns(Task.Run(() => new JSONQuery
-            {
-                WorkItems = new JSONQueryItem[] {
-                    new JSONQueryItem {
-                        Id = "Some Id 1",
-                        Url = new Uri("http://some/url/1")
-                    },
-                    new JSONQueryItem {
-                        Id = "Some Id 2",
-                        Url = new Uri("http://some/url/2")
-                    }
-                }
-            }));
-            this.requestMock.Setup(r => r.GetFullWorkItem(It.IsAny<Uri>())).Returns(Task.Run(() => (dynamic)null));
-            this.apiConverterMock.SetupSequence(a => a.ConvertToWorkItem(It.IsAny<object>())).Returns(new WorkItem
-            {
-                ChangesetId = "Some Changeset Id",
-                ClosedDate = new DateTime(2019, 04, 15),
-                WorkItemId = "Some Work Item Id"
-            }).Throws(new Exception("Some Exception!"));
-
-            var dict = this.azureDevOps.GetWorkItems();
-
-            var byDate = Assert.Single(dict.Values);
-            Assert.Single(byDate.Values);
-            this.loggerMock.Verify(l => l.LogToConsole(It.IsRegex(@"Error Processing Work Item 'Some Id \d+': Some Exception!")), Times.Once);
-        }
-
-        [Fact]
         public void WhenProcessWorkItemsWithSameDateThenReturnWorkItem()
         {
             this.requestMock.Setup(r => r.GetWorkItemList()).Returns(Task.Run(() => new JSONQuery


### PR DESCRIPTION
Removes try/catch that is throws odd message "Error Processing Work Item "XXX……': An item with the same key has already been added.

We shouldn't throw an error in the log that is not an error. If it is an error, we should fail, not keep going.

