### PR TITLE
Invoke produces and uses exit code

### DIFF
--- a/src/vcsparser.PowerShell.unittests/GivenAStartProcessSync.cs
+++ b/src/vcsparser.PowerShell.unittests/GivenAStartProcessSync.cs
@@ -33,7 +33,7 @@ namespace vcsparser.PowerShell.unittests
             startProcess.InjectDependencies(mockCmdlet.Object, mockProcessWrapper.Object, mockCommandLineParser.Object, mockLogger.Object);
 
             mockCommandLineParser.Setup(m => m.ParseCommandLine("cmd args")).Returns(new Tuple<string, string>("cmd", "args"));
-            mockProcessWrapper.Setup(m => m.Invoke("cmd", "args")).Returns(memoryStream);
+            mockProcessWrapper.Setup(m => m.Invoke("cmd", "args", It.IsAny<OutputLineDelegate>())).Returns(0);
         }
 
         [Fact]

--- a/src/vcsparser.PowerShell/GetGitLog.cs
+++ b/src/vcsparser.PowerShell/GetGitLog.cs
@@ -55,8 +55,12 @@ namespace vcsparser.PowerShell
         protected override void ProcessRecord()
         {
             var parsedCommand = this.commandLineParser.ParseCommandLine(this.GitLogCommand);
-            var stream = this.processWrapper.Invoke(parsedCommand.Item1, parsedCommand.Item2, WorkingDirectory);
-            var commits = this.gitLogParser.Parse(stream);
+            var lines = new List<string>();
+            var exitCode = this.processWrapper.Invoke(parsedCommand.Item1, parsedCommand.Item2, WorkingDirectory, (l) => { lines.Add(l); } );
+            if (exitCode != 0)
+                this.ThrowTerminatingError(new ErrorRecord(new Exception(string.Join(Environment.NewLine, lines)), $"Non zero return code: {exitCode}", ErrorCategory.OperationStopped, null));
+
+            var commits = this.gitLogParser.Parse(lines);
             this.cmdlet.WriteObject(commits);
         }
 

--- a/src/vcsparser.PowerShell/GetGitLog.cs
+++ b/src/vcsparser.PowerShell/GetGitLog.cs
@@ -55,12 +55,11 @@ namespace vcsparser.PowerShell
         protected override void ProcessRecord()
         {
             var parsedCommand = this.commandLineParser.ParseCommandLine(this.GitLogCommand);
-            var lines = new List<string>();
-            var exitCode = this.processWrapper.Invoke(parsedCommand.Item1, parsedCommand.Item2, WorkingDirectory, (l) => { lines.Add(l); } );
-            if (exitCode != 0)
-                this.ThrowTerminatingError(new ErrorRecord(new Exception(string.Join(Environment.NewLine, lines)), $"Non zero return code: {exitCode}", ErrorCategory.OperationStopped, null));
+            var invoke = this.processWrapper.Invoke(parsedCommand.Item1, parsedCommand.Item2, WorkingDirectory);
+            if (invoke.Item1 != 0)
+                this.ThrowTerminatingError(new ErrorRecord(new Exception(string.Join(Environment.NewLine, invoke.Item2)), $"Non zero return code: {invoke.Item1}", ErrorCategory.OperationStopped, this));
 
-            var commits = this.gitLogParser.Parse(lines);
+            var commits = this.gitLogParser.Parse(invoke.Item2);
             this.cmdlet.WriteObject(commits);
         }
 

--- a/src/vcsparser.PowerShell/GetPerforceChanges.cs
+++ b/src/vcsparser.PowerShell/GetPerforceChanges.cs
@@ -49,12 +49,11 @@ namespace vcsparser.PowerShell
             base.ProcessRecord();
 
             var commandLine = this.commandLineParser.ParseCommandLine(this.ChangesCommand);
-            var lines = new List<string>();
-            var exitCode = this.processWrapper.Invoke(commandLine.Item1, commandLine.Item2, (l) => { lines.Add(l); });
-            if (exitCode != 0)
-                this.ThrowTerminatingError(new ErrorRecord(new Exception(string.Join(Environment.NewLine, lines)), $"Non zero return code: {exitCode}", ErrorCategory.OperationStopped, null));
+            var invoke = this.processWrapper.Invoke(commandLine.Item1, commandLine.Item2);
+            if (invoke.Item1 != 0)
+                this.ThrowTerminatingError(new ErrorRecord(new Exception(string.Join(Environment.NewLine, invoke.Item2)), $"Non zero return code: {invoke.Item1}", ErrorCategory.OperationStopped, this));
 
-            var changes = this.changesParser.Parse(lines);
+            var changes = this.changesParser.Parse(invoke.Item2);
             this.cmdlet.WriteObject(changes);
         }
 

--- a/src/vcsparser.PowerShell/GetPerforceChanges.cs
+++ b/src/vcsparser.PowerShell/GetPerforceChanges.cs
@@ -49,8 +49,12 @@ namespace vcsparser.PowerShell
             base.ProcessRecord();
 
             var commandLine = this.commandLineParser.ParseCommandLine(this.ChangesCommand);
-            var stream = this.processWrapper.Invoke(commandLine.Item1, commandLine.Item2);
-            var changes = this.changesParser.Parse(stream);
+            var lines = new List<string>();
+            var exitCode = this.processWrapper.Invoke(commandLine.Item1, commandLine.Item2, (l) => { lines.Add(l); });
+            if (exitCode != 0)
+                this.ThrowTerminatingError(new ErrorRecord(new Exception(string.Join(Environment.NewLine, lines)), $"Non zero return code: {exitCode}", ErrorCategory.OperationStopped, null));
+
+            var changes = this.changesParser.Parse(lines);
             this.cmdlet.WriteObject(changes);
         }
 

--- a/src/vcsparser.PowerShell/GetPerforceChangeset.cs
+++ b/src/vcsparser.PowerShell/GetPerforceChangeset.cs
@@ -55,12 +55,11 @@ namespace vcsparser.PowerShell
         protected override void ProcessRecord()
         {
             var parsedCommandLine = commandLineParser.ParseCommandLine(String.Format(DescribeCommand, Changeset));
-            var lines = new List<string>();
-            var exitCode = this.processWrapper.Invoke(parsedCommandLine.Item1, parsedCommandLine.Item2, (l) => { lines.Add(l); });
-            if (exitCode != 0)
-                this.ThrowTerminatingError(new ErrorRecord(new Exception(string.Join(Environment.NewLine, lines)), $"Non zero return code: {exitCode}", ErrorCategory.OperationStopped, null));
+            var invoke = this.processWrapper.Invoke(parsedCommandLine.Item1, parsedCommandLine.Item2);
+            if (invoke.Item1 != 0)
+                this.ThrowTerminatingError(new ErrorRecord(new Exception(string.Join(Environment.NewLine, invoke.Item2)), $"Non zero return code: {invoke.Item1}", ErrorCategory.OperationStopped, this));
 
-            var changeset = describeParser.Parse(lines);
+            var changeset = describeParser.Parse(invoke.Item2);
             this.cmdlet.WriteObject(changeset);
         }        
 

--- a/src/vcsparser.PowerShell/GetPerforceChangeset.cs
+++ b/src/vcsparser.PowerShell/GetPerforceChangeset.cs
@@ -55,8 +55,12 @@ namespace vcsparser.PowerShell
         protected override void ProcessRecord()
         {
             var parsedCommandLine = commandLineParser.ParseCommandLine(String.Format(DescribeCommand, Changeset));
-            var stream = processWrapper.Invoke(parsedCommandLine.Item1, parsedCommandLine.Item2);
-            var changeset = describeParser.Parse(stream);
+            var lines = new List<string>();
+            var exitCode = this.processWrapper.Invoke(parsedCommandLine.Item1, parsedCommandLine.Item2, (l) => { lines.Add(l); });
+            if (exitCode != 0)
+                this.ThrowTerminatingError(new ErrorRecord(new Exception(string.Join(Environment.NewLine, lines)), $"Non zero return code: {exitCode}", ErrorCategory.OperationStopped, null));
+
+            var changeset = describeParser.Parse(lines);
             this.cmdlet.WriteObject(changeset);
         }        
 

--- a/src/vcsparser.core/IProcessWrapper.cs
+++ b/src/vcsparser.core/IProcessWrapper.cs
@@ -11,9 +11,6 @@ namespace vcsparser.core
 
     public interface IProcessWrapper
     {
-        Stream Invoke(string executable, string arguments);
-        Stream Invoke(string executable, string arguments, string workingDir);
-
         /// <summary>
         /// Calls an external executable with specified arguments, invoking a callback for each line of standard
         /// output.
@@ -24,6 +21,15 @@ namespace vcsparser.core
         /// <param name="outputLineCallback"></param>
         /// <returns></returns>
         int Invoke(string executable, string arguments, string workingDir, OutputLineDelegate outputLineCallback);
+
+        /// <summary>
+        /// Calls an external executable with specified arguments, invoking a callback for each line of standard
+        /// output.
+        /// </summary>
+        /// <param name="executable"></param>
+        /// <param name="arguments"></param>
+        /// <param name="outputLineCallback"></param>
+        /// <returns></returns>
         int Invoke(string executable, string arguments, OutputLineDelegate outputLineCallback);
     }
 }

--- a/src/vcsparser.core/IProcessWrapper.cs
+++ b/src/vcsparser.core/IProcessWrapper.cs
@@ -24,5 +24,6 @@ namespace vcsparser.core
         /// <param name="outputLineCallback"></param>
         /// <returns></returns>
         int Invoke(string executable, string arguments, string workingDir, OutputLineDelegate outputLineCallback);
+        int Invoke(string executable, string arguments, OutputLineDelegate outputLineCallback);
     }
 }

--- a/src/vcsparser.core/IProcessWrapper.cs
+++ b/src/vcsparser.core/IProcessWrapper.cs
@@ -21,15 +21,9 @@ namespace vcsparser.core
         /// <param name="outputLineCallback"></param>
         /// <returns></returns>
         int Invoke(string executable, string arguments, string workingDir, OutputLineDelegate outputLineCallback);
-
-        /// <summary>
-        /// Calls an external executable with specified arguments, invoking a callback for each line of standard
-        /// output.
-        /// </summary>
-        /// <param name="executable"></param>
-        /// <param name="arguments"></param>
-        /// <param name="outputLineCallback"></param>
-        /// <returns></returns>
         int Invoke(string executable, string arguments, OutputLineDelegate outputLineCallback);
+
+        Tuple<int, List<string>> Invoke(string executable, string arguments, string workingDir);
+        Tuple<int, List<string>> Invoke(string executable, string arguments);
     }
 }

--- a/src/vcsparser.core/ProcessWrapper.cs
+++ b/src/vcsparser.core/ProcessWrapper.cs
@@ -22,27 +22,8 @@ namespace vcsparser.core
             return process;
         }
 
-        public Stream Invoke(string executable, string args)
+        private void StartProcess(Process process, OutputLineDelegate outputLineCallback)
         {
-            var process = CreateProcessWithBaseParams(executable, args);
-
-            process.Start();                        
-            return process.StandardOutput.BaseStream;
-        }        
-
-        public Stream Invoke(string executable, string args, string workingDir)
-        {
-            var process = CreateProcessWithBaseParams(executable, args);
-            process.StartInfo.WorkingDirectory = workingDir;
-
-            process.Start();
-            return process.StandardOutput.BaseStream;
-        }
-
-        public int Invoke(string executable, string arguments, OutputLineDelegate outputLineCallback)
-        {
-            var process = CreateProcessWithBaseParams(executable, arguments);
-
             process.Start();
 
             var sr = new StreamReader(process.StandardOutput.BaseStream);
@@ -52,7 +33,12 @@ namespace vcsparser.core
                 if (outputLineCallback != null)
                     outputLineCallback(line);
             }
+        }
 
+        public int Invoke(string executable, string arguments, OutputLineDelegate outputLineCallback)
+        {
+            var process = CreateProcessWithBaseParams(executable, arguments);
+            StartProcess(process, outputLineCallback);
             return process.ExitCode;
         }
 
@@ -60,17 +46,7 @@ namespace vcsparser.core
         {
             var process = CreateProcessWithBaseParams(executable, arguments);
             process.StartInfo.WorkingDirectory = workingDir;
-
-            process.Start();            
-
-            var sr = new StreamReader(process.StandardOutput.BaseStream);
-            while (!sr.EndOfStream)
-            {
-                var line = sr.ReadLine();
-                if (outputLineCallback != null)
-                    outputLineCallback(line);                    
-            }
-
+            StartProcess(process, outputLineCallback);
             return process.ExitCode;
         }
     }

--- a/src/vcsparser.core/ProcessWrapper.cs
+++ b/src/vcsparser.core/ProcessWrapper.cs
@@ -49,5 +49,22 @@ namespace vcsparser.core
             StartProcess(process, outputLineCallback);
             return process.ExitCode;
         }
+
+        public Tuple<int, List<string>> Invoke(string executable, string arguments)
+        {
+            var process = CreateProcessWithBaseParams(executable, arguments);
+            var lines = new List<string>();
+            StartProcess(process, (l) => { lines.Add(l); });
+            return new Tuple<int, List<string>>(process.ExitCode, lines);
+        }
+
+        public Tuple<int, List<string>> Invoke(string executable, string arguments, string workingDir)
+        {
+            var process = CreateProcessWithBaseParams(executable, arguments);
+            process.StartInfo.WorkingDirectory = workingDir;
+            var lines = new List<string>();
+            StartProcess(process, (l) => { lines.Add(l); });
+            return new Tuple<int, List<string>>(process.ExitCode, lines);
+        }
     }
 }

--- a/src/vcsparser.core/ProcessWrapper.cs
+++ b/src/vcsparser.core/ProcessWrapper.cs
@@ -39,6 +39,23 @@ namespace vcsparser.core
             return process.StandardOutput.BaseStream;
         }
 
+        public int Invoke(string executable, string arguments, OutputLineDelegate outputLineCallback)
+        {
+            var process = CreateProcessWithBaseParams(executable, arguments);
+
+            process.Start();
+
+            var sr = new StreamReader(process.StandardOutput.BaseStream);
+            while (!sr.EndOfStream)
+            {
+                var line = sr.ReadLine();
+                if (outputLineCallback != null)
+                    outputLineCallback(line);
+            }
+
+            return process.ExitCode;
+        }
+
         public int Invoke(string executable, string arguments, string workingDir, OutputLineDelegate outputLineCallback)
         {
             var process = CreateProcessWithBaseParams(executable, arguments);

--- a/src/vcsparser.core/git/GitCodeChurnProcessor.cs
+++ b/src/vcsparser.core/git/GitCodeChurnProcessor.cs
@@ -57,12 +57,11 @@ namespace vcsparser.core.git
             logger.LogToConsole("Invoking " + args.GitLogCommand);
             var parsedCommand = this.commandLineParser.ParseCommandLine(args.GitLogCommand);
 
-            var lines = new List<string>();
-            var exitCode = this.processWrapper.Invoke(parsedCommand.Item1, parsedCommand.Item2, (l) => { lines.Add(l); });
-            if (exitCode != 0)
-                return exitCode;
+            var invoke = this.processWrapper.Invoke(parsedCommand.Item1, parsedCommand.Item2);
+            if (invoke.Item1 != 0)
+                return invoke.Item1;
 
-            var changesets = gitLogParser.Parse(lines);
+            var changesets = gitLogParser.Parse(invoke.Item2);
             logger.LogToConsole($"Found {changesets.Count} changesets to parse");
 
             this.bugDatabaseProcessor.ProcessCache(args.BugDatabaseOutputFile, this.changesetProcessor);

--- a/src/vcsparser.core/git/GitCodeChurnProcessor.cs
+++ b/src/vcsparser.core/git/GitCodeChurnProcessor.cs
@@ -52,13 +52,18 @@ namespace vcsparser.core.git
             this.outputProcessor.ProcessOutput(args.BugDatabaseOutputType, args.BugDatabaseOutputFile, bugCache);
         }
 
-        public void Extract()
+        public int Extract()
         {
             logger.LogToConsole("Invoking " + args.GitLogCommand);
             var parsedCommand = this.commandLineParser.ParseCommandLine(args.GitLogCommand);
-            var stream = this.processWrapper.Invoke(parsedCommand.Item1, parsedCommand.Item2);
-            var changesets = gitLogParser.Parse(stream);
-            logger.LogToConsole("Found " + changesets.Count + " changesets");
+
+            var lines = new List<string>();
+            var exitCode = this.processWrapper.Invoke(parsedCommand.Item1, parsedCommand.Item2, (l) => { lines.Add(l); });
+            if (exitCode != 0)
+                return exitCode;
+
+            var changesets = gitLogParser.Parse(lines);
+            logger.LogToConsole($"Found {changesets.Count} changesets to parse");
 
             this.bugDatabaseProcessor.ProcessCache(args.BugDatabaseOutputFile, this.changesetProcessor);
 
@@ -70,6 +75,7 @@ namespace vcsparser.core.git
             logger.LogToConsole(this.changesetProcessor.Output.Count + " dates to output");
 
             this.outputProcessor.ProcessOutput(args.OutputType, args.OutputFile, this.changesetProcessor.Output);
+            return 0;
         }
     }
 }

--- a/src/vcsparser.core/git/GitLogParser.cs
+++ b/src/vcsparser.core/git/GitLogParser.cs
@@ -33,6 +33,16 @@ namespace vcsparser.core.git
             return context.Commits;                
         }
 
+        public List<GitCommit> Parse(List<string> lines)
+        {
+            GitLogParserContext context = new GitLogParserContext();
+            foreach (var line in lines)
+            {
+                ParseLine(context, line);
+            }
+            return context.Commits;
+        }
+
         private void ParseLine(GitLogParserContext context, String line)
         {
             if (line.StartsWith(COMMIT_PREFIX))

--- a/src/vcsparser.core/git/GitLogParser.cs
+++ b/src/vcsparser.core/git/GitLogParser.cs
@@ -17,22 +17,6 @@ namespace vcsparser.core.git
         public readonly String COMMIT_DATE_PREFIX = "CommitDate: ";
         public readonly String MERGE_PREFIX = "Merge: ";
 
-        public List<GitCommit> Parse(Stream stream)
-        {
-            GitLogParserContext context = new GitLogParserContext();
-            var reader = new StreamReader(stream);
-            using (stream)
-            {
-                var line = reader.ReadLine();
-                while (line != null)
-                {
-                    ParseLine(context, line);
-                    line = reader.ReadLine();
-                }
-            }
-            return context.Commits;                
-        }
-
         public List<GitCommit> Parse(List<string> lines)
         {
             GitLogParserContext context = new GitLogParserContext();

--- a/src/vcsparser.core/git/IGitLogParser.cs
+++ b/src/vcsparser.core/git/IGitLogParser.cs
@@ -10,5 +10,6 @@ namespace vcsparser.core.git
     public interface IGitLogParser
     {
         List<GitCommit> Parse(Stream stream);
+        List<GitCommit> Parse(List<string> lines);
     }
 }

--- a/src/vcsparser.core/git/IGitLogParser.cs
+++ b/src/vcsparser.core/git/IGitLogParser.cs
@@ -9,7 +9,6 @@ namespace vcsparser.core.git
 {
     public interface IGitLogParser
     {
-        List<GitCommit> Parse(Stream stream);
         List<GitCommit> Parse(List<string> lines);
     }
 }

--- a/src/vcsparser.core/p4/ChangesParser.cs
+++ b/src/vcsparser.core/p4/ChangesParser.cs
@@ -9,20 +9,6 @@ namespace vcsparser.core.p4
 {
     public class ChangesParser : IChangesParser
     {
-        public List<int> Parse(Stream ms)
-        {
-            var result = new List<int>();
-
-            var sr = new StreamReader(ms);
-            while (!sr.EndOfStream)
-            {
-                var line = sr.ReadLine();
-                result.Add(ParseLine(line));
-            }
-
-            return result;            
-        }
-
         public List<int> Parse(List<string> lines)
         {
             var result = new List<int>();

--- a/src/vcsparser.core/p4/ChangesParser.cs
+++ b/src/vcsparser.core/p4/ChangesParser.cs
@@ -23,6 +23,17 @@ namespace vcsparser.core.p4
             return result;            
         }
 
+        public List<int> Parse(List<string> lines)
+        {
+            var result = new List<int>();
+            foreach (var line in lines)
+            {
+                result.Add(ParseLine(line));
+            }
+
+            return result;
+        }
+
         private int ParseLine(string line)
         {
             var splittedString = line.Split(' ');

--- a/src/vcsparser.core/p4/DescribeParser.cs
+++ b/src/vcsparser.core/p4/DescribeParser.cs
@@ -24,6 +24,19 @@ namespace vcsparser.core.p4
             return result;
         }
 
+        public PerforceChangeset Parse(List<string> lines)
+        {
+            var result = new PerforceChangeset();
+            FileChanges currentFileChanges = null;
+
+            foreach (var line in lines)
+            {
+                ParseLine(ref currentFileChanges, line, result);
+            }
+
+            return result;
+        }
+
         private void ParseLine(ref FileChanges currentFileChanges, string line, PerforceChangeset changeset)
         {            
             if (line.StartsWith("Change "))

--- a/src/vcsparser.core/p4/DescribeParser.cs
+++ b/src/vcsparser.core/p4/DescribeParser.cs
@@ -9,21 +9,6 @@ namespace vcsparser.core.p4
 {
     public class DescribeParser : IDescribeParser
     {
-        public PerforceChangeset Parse(Stream ms)
-        {
-            var result = new PerforceChangeset();
-            FileChanges currentFileChanges = null;
-
-            var sr = new StreamReader(ms);
-            while (!sr.EndOfStream)
-            {
-                var line = sr.ReadLine();
-                ParseLine(ref currentFileChanges, line, result);
-            }
-
-            return result;
-        }
-
         public PerforceChangeset Parse(List<string> lines)
         {
             var result = new PerforceChangeset();

--- a/src/vcsparser.core/p4/IChangesParser.cs
+++ b/src/vcsparser.core/p4/IChangesParser.cs
@@ -10,5 +10,6 @@ namespace vcsparser.core.p4
     public interface IChangesParser
     {
         List<int> Parse(Stream ms);
+        List<int> Parse(List<string> lines);
     }
 }

--- a/src/vcsparser.core/p4/IChangesParser.cs
+++ b/src/vcsparser.core/p4/IChangesParser.cs
@@ -9,7 +9,6 @@ namespace vcsparser.core.p4
 {
     public interface IChangesParser
     {
-        List<int> Parse(Stream ms);
         List<int> Parse(List<string> lines);
     }
 }

--- a/src/vcsparser.core/p4/IDescribeParser.cs
+++ b/src/vcsparser.core/p4/IDescribeParser.cs
@@ -9,7 +9,6 @@ namespace vcsparser.core.p4
 {
     public interface IDescribeParser
     {
-        PerforceChangeset Parse(Stream ms);
         PerforceChangeset Parse(List<string> lines);
     }
 }

--- a/src/vcsparser.core/p4/IDescribeParser.cs
+++ b/src/vcsparser.core/p4/IDescribeParser.cs
@@ -10,5 +10,6 @@ namespace vcsparser.core.p4
     public interface IDescribeParser
     {
         PerforceChangeset Parse(Stream ms);
+        PerforceChangeset Parse(List<string> lines);
     }
 }

--- a/src/vcsparser.core/p4/PerforceCodeChurnProcessor.cs
+++ b/src/vcsparser.core/p4/PerforceCodeChurnProcessor.cs
@@ -38,15 +38,6 @@ namespace vcsparser.core.p4
             this.changesetProcessor = new ChangesetProcessor(args.BugRegexes, this.logger);
         }
 
-        private IList<int> ParseChangeSets(string changesCommandLine)
-        {
-            this.logger.LogToConsole("Invoking: " + changesCommandLine);
-            var parsedCommandLine = this.commandLineParser.ParseCommandLine(changesCommandLine);
-            var stdOutStream = this.processWrapper.Invoke(parsedCommandLine.Item1, parsedCommandLine.Item2);
-
-            return this.changesParser.Parse(stdOutStream);
-        }
-
         public void QueryBugDatabase()
         {
             if (string.IsNullOrWhiteSpace(args.BugDatabaseDLL))
@@ -63,11 +54,18 @@ namespace vcsparser.core.p4
             this.outputProcessor.ProcessOutput(args.BugDatabaseOutputType, args.BugDatabaseOutputFile, bugCache);
         }
 
-        public void Extract()
+        public int Extract()
         {
-            var changes = ParseChangeSets(args.P4ChangesCommandLine);
+            logger.LogToConsole("Invoking: " + args.P4ChangesCommandLine);
+            var parsedCommand = this.commandLineParser.ParseCommandLine(args.P4ChangesCommandLine);
 
-            this.logger.LogToConsole(String.Format("Found {0} changesets to parse", changes.Count));
+            var lines = new List<string>();
+            var exitCode = this.processWrapper.Invoke(parsedCommand.Item1, parsedCommand.Item2, (l) => { lines.Add(l); });
+            if (exitCode != 0)
+                return exitCode;
+
+            var changes = changesParser.Parse(lines);
+            logger.LogToConsole($"Found {changes.Count} changesets to parse");
 
             this.bugDatabaseProcessor.ProcessCache(args.BugDatabaseOutputFile, this.changesetProcessor);
 
@@ -79,13 +77,20 @@ namespace vcsparser.core.p4
                 ReportProgressAfterOneMinute(i, changes);                
 
                 var cmd = commandLineParser.ParseCommandLine(String.Format(args.P4DescribeCommandLine, change));
-                changesetProcessor.ProcessChangeset(describeParser.Parse(this.processWrapper.Invoke(cmd.Item1, cmd.Item2)));
+
+                var describeLines = new List<string>();
+                var describeExitCode = this.processWrapper.Invoke(cmd.Item1, cmd.Item2, (l) => { lines.Add(l); });
+                if (describeExitCode != 0)
+                    return describeExitCode;
+
+                changesetProcessor.ProcessChangeset(describeParser.Parse(describeLines));
 
                 i++;
             }
             this.stopWatch.Stop();
 
             this.outputProcessor.ProcessOutput(args.OutputType, args.OutputFile, this.changesetProcessor.Output);
+            return 0;
         }
 
         private void ReportProgressAfterOneMinute(int currentChangeset, IList<int> changes)

--- a/src/vcsparser.unittests/GivenAProcessWrapper.cs
+++ b/src/vcsparser.unittests/GivenAProcessWrapper.cs
@@ -15,18 +15,16 @@ namespace vcsparser.unittests
         public void WhenInvokingShouldCallProcessAndRedirectStdOut()
         {
             var processWrapper = new ProcessWrapper();
-            var rd = new StreamReader(processWrapper.Invoke("cmd", "/c dir"));
-            string output = rd.ReadToEnd();
-            Assert.NotEmpty(output);            
+            var invoke = processWrapper.Invoke("cmd", "/c dir");
+            Assert.NotEmpty(invoke.Item2);            
         }
 
         [Fact]
         public void WhenInvokingWithWorkingDirShouldCallProcessAndRedirectStdOut()
         {
             var processWrapper = new ProcessWrapper();
-            var rd = new StreamReader(processWrapper.Invoke("cmd", "/c dir", "C:\\"));
-            string output = rd.ReadToEnd();
-            Assert.NotEmpty(output);
+            var invoke = processWrapper.Invoke("cmd", "/c dir", "C:\\");
+            Assert.NotEmpty(invoke.Item2);
         }
 
         [Fact]

--- a/src/vcsparser.unittests/GivenAProcessWrapper.cs
+++ b/src/vcsparser.unittests/GivenAProcessWrapper.cs
@@ -20,6 +20,15 @@ namespace vcsparser.unittests
         }
 
         [Fact]
+        public void WhenInvokingAndCallbackShouldCallProcessAndRedirectStdOut()
+        {
+            string data = "";
+            var processWrapper = new ProcessWrapper();
+            var invoke = processWrapper.Invoke("cmd", "/c dir", (l) => { data += l; });
+            Assert.NotEmpty(data);
+        }
+
+        [Fact]
         public void WhenInvokingWithWorkingDirShouldCallProcessAndRedirectStdOut()
         {
             var processWrapper = new ProcessWrapper();
@@ -37,10 +46,26 @@ namespace vcsparser.unittests
         }
 
         [Fact]
+        public void WhenInvokingWithWorkingDirAndReturnZero()
+        {
+            var processWrapper = new ProcessWrapper();
+            var invoke = processWrapper.Invoke("cmd", "/c dir", "C:\\");
+            Assert.Equal(0, invoke.Item1);
+            Assert.True(invoke.Item2.Count > 0);
+        }
+
+        [Fact]
         public void WhenInvokingWithWorkingDirAndCallbackShouldReturn0()
         {            
             var processWrapper = new ProcessWrapper();
             Assert.Equal(0, processWrapper.Invoke("cmd", "/c dir", "C:\\", null));            
+        }
+
+        [Fact]
+        public void WhenInvokingWithWorkingDirShouldReturn0()
+        {
+            var processWrapper = new ProcessWrapper();
+            Assert.Equal(0, processWrapper.Invoke("cmd", "/c dir", "C:\\").Item1);
         }
     }
 }

--- a/src/vcsparser.unittests/git/GivenAGitLogParser.cs
+++ b/src/vcsparser.unittests/git/GivenAGitLogParser.cs
@@ -18,19 +18,17 @@ namespace vcsparser.unittests.git
             parser = new GitLogParser();
         }
 
-        private MemoryStream GetStreamWithContent(string content)
+        private List<string> GetListWithContent(string content)
         {
-            var ms = new MemoryStream();
-            var sw = new StreamWriter(ms);
-            sw.Write(content);
-            sw.Flush();
-            ms.Seek(0, SeekOrigin.Begin);
-            return ms;
+            return new List<string>(content.Split(
+                new[] { "\n", Environment.NewLine },
+                StringSplitOptions.None
+            ));
         }
 
         [Fact]
         public void WhenConvertingIsoDateStringToDateShouldReturnExpectedValue()
-        {            
+        {
             var dateTime = parser.Iso8601StringToDateTime("2018-09-19T14:19:14+01:00");
             Assert.Equal(new DateTime(2018, 09, 19, 14, 19, 14), dateTime);
         }
@@ -38,17 +36,17 @@ namespace vcsparser.unittests.git
         [Fact]
         public void WhenParsingShouldReturnExpectedResult()
         {
-            var stream = GetStreamWithContent(Resources.GitExample1);
-            var changesets = parser.Parse(stream);
+            var list = GetListWithContent(Resources.GitExample1);
+            var changesets = parser.Parse(list);
 
             Assert.Equal(2, changesets.Count);
         }
 
         [Fact]
         public void WhenParsingCommitWithDescriptionShouldReturnExpectedValues() {
-            var stream = GetStreamWithContent(Resources.GitExample1);            
+            var list = GetListWithContent(Resources.GitExample1);
 
-            GitCommit commit = this.parser.Parse(stream)[0];
+            GitCommit commit = this.parser.Parse(list)[0];
             Assert.Equal("82419fcdc1fca1f8b14905366159837bfe8a1be4", commit.CommitHash);
             Assert.Equal("Author Name <author@email.com>", commit.Author);
             Assert.Equal(new DateTime(2018, 09, 19, 14, 19, 14), commit.AuthorDate);
@@ -59,9 +57,9 @@ namespace vcsparser.unittests.git
 
         [Fact]
         public void WhenParsingCommitWithoutDescriptionShouldReturnExpectedValues(){
-            var stream = GetStreamWithContent(Resources.GitExample1);
+            var list = GetListWithContent(Resources.GitExample1);
 
-            GitCommit commit = this.parser.Parse(stream)[1];            
+            GitCommit commit = this.parser.Parse(list)[1];
             Assert.Equal("31b45b8417418c3562d19eab8830ed786ac40f40", commit.CommitHash);
             Assert.Equal("Author Name <author@email.com>", commit.Author);
             Assert.Equal(new DateTime(2018, 09, 18, 16, 48, 22), commit.AuthorDate);
@@ -69,12 +67,12 @@ namespace vcsparser.unittests.git
             Assert.Equal(new DateTime(2018, 09, 18, 16, 48, 22), commit.CommiterDate);
             Assert.Equal("This one only has the commit message. No long description\r\n", commit.ChangesetMessage);
         }
-        
+
         [Fact]
         public void WhenParsingCommitShouldParseStatsCorrectly(){
-            var stream = GetStreamWithContent(Resources.GitExample1);
+            var list = GetListWithContent(Resources.GitExample1);
 
-            GitCommit commit = this.parser.Parse(stream)[0];
+            GitCommit commit = this.parser.Parse(list)[0];
             Assert.Equal(3, commit.ChangesetFileChanges.Count);
             Assert.Equal(1, commit.ChangesetFileChanges[0].Added);
             Assert.Equal(1, commit.ChangesetFileChanges[0].Deleted);
@@ -91,9 +89,9 @@ namespace vcsparser.unittests.git
 
         [Fact]
         public void WhenParsingSubsequentCommitsShouldParseStatsCorrectly() {
-            var stream = GetStreamWithContent(Resources.GitExample1);
+            var list = GetListWithContent(Resources.GitExample1);
 
-            GitCommit commit = this.parser.Parse(stream)[1];
+            GitCommit commit = this.parser.Parse(list)[1];
             Assert.Equal(2, commit.ChangesetFileChanges.Count);
 
             Assert.Equal(4, commit.ChangesetFileChanges[1].Added);
@@ -104,9 +102,9 @@ namespace vcsparser.unittests.git
         [Fact]
         public void WhenParsingCommitWithBinaryFilesShouldGetResultsCorrectly()
         {
-            var stream = GetStreamWithContent(Resources.GitExample2);
+            var list = GetListWithContent(Resources.GitExample2);
 
-            GitCommit commit = this.parser.Parse(stream)[0];
+            GitCommit commit = this.parser.Parse(list)[0];
             Assert.Single(commit.ChangesetFileChanges);
             Assert.Equal("src/dir-with-dashes/File1.cs", commit.ChangesetFileChanges[0].FileName);
             Assert.Equal(0, commit.ChangesetFileChanges[0].Added);
@@ -116,8 +114,8 @@ namespace vcsparser.unittests.git
         [Fact]
         public void WhenParsingLogWithRenameHistoryShouldReturnExpectedValues()
         {
-            var stream = GetStreamWithContent(Resources.GitExample3);
-            var commits = this.parser.Parse(stream);
+            var list = GetListWithContent(Resources.GitExample3);
+            var commits = this.parser.Parse(list);
 
             Assert.Equal(3, commits.Count);
             Assert.Equal(3, commits[0].ChangesetFileChanges[0].Added);
@@ -161,11 +159,11 @@ namespace vcsparser.unittests.git
         [Fact]
         public void WhenParsingMergeShouldNotThrow()
         {
-            var stream = GetStreamWithContent(Resources.GitExample4);
+            var list = GetListWithContent(Resources.GitExample4);
 
-            this.parser.Parse(stream);
+            this.parser.Parse(list);
         }
 
-        
+
 }
 }

--- a/src/vcsparser.unittests/p4/GivenAChangesParser.cs
+++ b/src/vcsparser.unittests/p4/GivenAChangesParser.cs
@@ -18,22 +18,20 @@ namespace vcsparser.unittests
             this.parser = new ChangesParser();
         }
 
-        private MemoryStream GetStreamWithContent(string content)
+        private List<string> GetListWithContent(string content)
         {
-            var ms = new MemoryStream();
-            var sw = new StreamWriter(ms);
-            sw.Write(content);
-            sw.Flush();
-            ms.Seek(0, SeekOrigin.Begin);
-            return ms;
+            return new List<string>(content.Split(
+                new[] { "\n", Environment.NewLine },
+                StringSplitOptions.None
+            ));
         }
 
         [Fact]
         public void WhenParsingChangesWithValidFileShouldReturnChangeNumbers()
         {
-            var ms = GetStreamWithContent(Resources.ChangesFiles1);
+            var lines = GetListWithContent(Resources.ChangesFiles1);
 
-            var changeNumbers = this.parser.Parse(ms);
+            var changeNumbers = this.parser.Parse(lines);
 
             Assert.Equal(144545, changeNumbers[0]);
             Assert.Equal(144544, changeNumbers[1]);
@@ -50,9 +48,9 @@ namespace vcsparser.unittests
         [Fact]
         public void WhenParsingEmptyFileShouldReturnEmptyList()
         {
-            var ms = new MemoryStream();
+            var lines = new List<string>();
 
-            var changeNumbers = this.parser.Parse(ms);
+            var changeNumbers = this.parser.Parse(lines);
 
             Assert.Empty(changeNumbers);
         }
@@ -60,25 +58,25 @@ namespace vcsparser.unittests
         [Fact]
         public void WhenParsingFileWithBadContentShouldThrowInvalidFormatException()
         {
-            var ms = GetStreamWithContent("someinvalidcontent");
+            var lines = GetListWithContent("someinvalidcontent");
 
-            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(ms); });
+            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(lines); });
         }
 
         [Fact]
         public void WhenParsingFileWithBadContent2ShouldThrowInvalidFormatException()
         {
-            var ms = GetStreamWithContent("some invalid content");
+            var lines = GetListWithContent("some invalid content");
 
-            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(ms); });
+            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(lines); });
         }
 
         [Fact]
         public void WhenParsingFileWithBadContent3ShouldThrowInvalidFormatException()
         {
-            var ms = GetStreamWithContent("Change shouldbeanumberhere");
+            var lines = GetListWithContent("Change shouldbeanumberhere");
 
-            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(ms); });
+            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(lines); });
         }
     }
 }

--- a/src/vcsparser.unittests/p4/GivenADescribeParser.cs
+++ b/src/vcsparser.unittests/p4/GivenADescribeParser.cs
@@ -19,22 +19,20 @@ namespace vcsparser.unittests
             this.parser = new DescribeParser();
         }
 
-        private MemoryStream GetStreamWithContent(string content)
+        private List<string> GetListWithContent(string content)
         {
-            var ms = new MemoryStream();
-            var sw = new StreamWriter(ms);
-            sw.Write(content);
-            sw.Flush();
-            ms.Seek(0, SeekOrigin.Begin);
-            return ms;
+            return new List<string>(content.Split(
+                new[] { Environment.NewLine },
+                StringSplitOptions.None
+            ));
         }
 
         [Fact]
         public void WhenParsingShouldReturnExceptedValues()
         {
-            var ms = GetStreamWithContent(Resources.DescribeFile1);
+            var lines = GetListWithContent(Resources.DescribeFile1);
 
-            var result = this.parser.Parse(ms);
+            var result = this.parser.Parse(lines);
 
             Assert.Equal(141284, result.ChangesetNumber);
             Assert.Equal("author.name@author.name_workspace-machine", result.Author);
@@ -53,32 +51,32 @@ namespace vcsparser.unittests
         [Fact]
         public void WhenParsingFileWithInvalidChangeLineShouldThrowInvalidFormatException()
         {
-            var ms = GetStreamWithContent(Resources.DescribeFile2);
+            var lines = GetListWithContent(Resources.DescribeFile2);
             
-            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(ms); });
+            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(lines); });
         }
 
         [Fact]
         public void WhenParsingFileWithInvalidAuthorShouldThrowInvalidFormatException()
         {
-            var ms = GetStreamWithContent(Resources.DescribeFile3);
+            var lines = GetListWithContent(Resources.DescribeFile3);
 
-            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(ms); });
+            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(lines); });
         }
 
         [Fact]
         public void WhenParsingFileWithInvalidDateShouldThrowInvalidFormatException()
         {
-            var ms = GetStreamWithContent(Resources.DescribeFile4);
+            var lines = GetListWithContent(Resources.DescribeFile4);
 
-            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(ms); });
+            Assert.Throws<InvalidFormatException>(() => { this.parser.Parse(lines); });
         }
 
         [Fact]
         public void WhenParsingEmptyFileShouldReturnChangesetNumberZero()
         {
-            var ms = new MemoryStream();
-            var result = this.parser.Parse(ms);
+            var lines = new List<string>();
+            var result = this.parser.Parse(lines);
             Assert.Equal(0, result.ChangesetNumber);
         }
     }

--- a/src/vcsparser.unittests/p4/GivenAPerforceCodeChurnProcessor.cs
+++ b/src/vcsparser.unittests/p4/GivenAPerforceCodeChurnProcessor.cs
@@ -88,6 +88,19 @@ namespace vcsparser.unittests
         }
 
         [Fact]
+        public void WhenProcessingAndChangesNonZeroShouldReturnExitCode()
+        {
+            var invokeLines = new List<string>();
+
+            this.processWrapperMock.Setup(m => m.Invoke("changes", "commandline")).Returns(new Tuple<int, List<string>>(1, invokeLines));
+
+            var exitCode = this.processor.Extract();
+
+            this.processWrapperMock.Verify(m => m.Invoke(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            Assert.Equal(1, exitCode);
+        }
+
+        [Fact]
         public void WhenProcessingShouldInvokeDescribeParserForEachChange()
         {
             var invokeLines = new List<string>();
@@ -102,6 +115,22 @@ namespace vcsparser.unittests
             this.processor.Extract();
             this.processWrapperMock.Verify(m => m.Invoke("describe", "1"), Times.Once());
             this.processWrapperMock.Verify(m => m.Invoke("describe", "2"), Times.Once());
+        }
+
+        [Fact]
+        public void WhenProcessingAndeDescribeNonZeroShouldExitCode()
+        {
+            var invokeLines = new List<string>();
+            var describeLines = new List<string>();
+
+            this.processWrapperMock.Setup(m => m.Invoke("changes", "commandline")).Returns(new Tuple<int, List<string>>(0, invokeLines));
+            this.processWrapperMock.Setup(m => m.Invoke("describe", "1")).Returns(new Tuple<int, List<string>>(1, describeLines));
+            this.changesParserMock.Setup(m => m.Parse(invokeLines)).Returns(new List<int>() { 1 });
+
+            var exitCode = this.processor.Extract();
+
+            this.processWrapperMock.Verify(m => m.Invoke("describe", "1"), Times.Never());
+            Assert.Equal(1, exitCode);
         }
 
         [Fact]

--- a/src/vcsparser/Program.cs
+++ b/src/vcsparser/Program.cs
@@ -48,8 +48,7 @@ namespace vcsparser
             var processor = new PerforceCodeChurnProcessor(processWrapper, changesParser, describeParser, commandLineParser, bugDatabaseProcessor, logger, stopWatch, outputProcessor, a);
 
             processor.QueryBugDatabase();
-            processor.Extract();
-            return 0;
+            return processor.Extract();
         }
 
         private static int RunGitCodeChurnProcessor(GitExtractCommandLineArgs a)
@@ -68,8 +67,7 @@ namespace vcsparser
             var processor = new GitCodeChurnProcessor(commandLineParser, processWrapper, gitLogParser, outputProcessor, bugDatabaseProcessor, logger, a);
 
             processor.QueryBugDatabase();
-            processor.Extract();
-            return 0;
+            return processor.Extract();
         }
 
         private static int RunSonarGenericMetrics(SonarGenericMetricsCommandLineArgs a)


### PR DESCRIPTION
fixes #31 

- `p4extract` and `gitextract` exit codes
- All `ProcessWrapper.cs` methods have access to exit codes
- Powershell modules will throw if exit code non `0`