### PR TITLE
FilePrefixToRemove case insensitive

### DIFF
--- a/src/vcsparser.core/MeasureConverter.cs
+++ b/src/vcsparser.core/MeasureConverter.cs
@@ -111,7 +111,7 @@ namespace vcsparser.core
             if (filePrefixToRemove == null)
                 return fileName;
 
-            if (fileName.StartsWith(filePrefixToRemove))
+            if (fileName.StartsWith(filePrefixToRemove, StringComparison.OrdinalIgnoreCase))
                 return fileName.Substring(filePrefixToRemove.Length);
 
             return fileName;

--- a/src/vcsparser.core/MeasureConverterRaw.cs
+++ b/src/vcsparser.core/MeasureConverterRaw.cs
@@ -99,7 +99,7 @@ namespace vcsparser.core
             if (filePrefixToRemove == null)
                 return fileName;
 
-            if (fileName.StartsWith(filePrefixToRemove))
+            if (fileName.StartsWith(filePrefixToRemove, StringComparison.OrdinalIgnoreCase))
                 return fileName.Substring(filePrefixToRemove.Length);
 
             return fileName;

--- a/src/vcsparser.unittests/GivenAMeasureConverter.cs
+++ b/src/vcsparser.unittests/GivenAMeasureConverter.cs
@@ -97,6 +97,24 @@ namespace vcsparser.unittests
         }
 
         [Fact]
+        public void WhenConvertingWithinRangeAndDifferentCaseShouldRemoveFilePrefix()
+        {
+            var dailyCodeChurn = new DailyCodeChurn()
+            {
+                Timestamp = "2018/09/17 00:00:00",
+                FileName = "//PREfix/file",
+                Added = 10,
+                Deleted = 10
+            };
+            var measures = new SonarMeasuresJson();
+
+            this.measureConverter.ProcessFileMeasure(dailyCodeChurn, measures);
+
+            Assert.Equal("file",
+                measures.Measures.Where(m => m.MetricKey == "key").Single().File);
+        }
+
+        [Fact]
         public void WhenConvertingWithinRangeAndNoFilePrefixShouldConvert()
         {
             this.measureConverter = new MeasureConverter<int>(new DateTime(2018, 9, 17), new DateTime(2018, 9, 18), metric, mockMeasureAggregator.Object, null);

--- a/src/vcsparser.unittests/GivenAMeasureConverterRaw.cs
+++ b/src/vcsparser.unittests/GivenAMeasureConverterRaw.cs
@@ -72,6 +72,22 @@ namespace vcsparser.unittests
         }
 
         [Fact]
+        public void WhenConvertingWithinRangeAndDiffrentCaseShouldRemoveFilePrefix()
+        {
+            var dailyCodeChurn = new DailyCodeChurn()
+            {
+                Timestamp = "2018/09/17 00:00:00",
+                FileName = "//PREfix/file"
+            };
+            var measures = new SonarMeasuresJson();
+
+            this.measureConverter.ProcessFileMeasure(dailyCodeChurn, measures);
+
+            Assert.Equal("file",
+                measures.MeasuresRaw.Where(m => m.MetricKey == "key").Single().File);
+        }
+
+        [Fact]
         public void WhenConvertingWithinRangeAndNoFilePrefixShouldConvert()
         {
             this.measureConverter = new MeasureConverterRaw<string>(metric, mockMeasureAggregator.Object, null);


### PR DESCRIPTION
The cli argument `--fileprefixtoremove <prefix>` for `sonargenericmetrics` is now case insensitive