### PR TITLE
Make code CultureInfo idempotent.

### DIFF
--- a/src/vcsparser.core/ChangesetProcessor.cs
+++ b/src/vcsparser.core/ChangesetProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -93,7 +94,7 @@ namespace vcsparser.core
                 dict[changeset.ChangesetTimestamp.Date].Add(fileName, new DailyCodeChurn());
 
             var dailyCodeChurn = dict[changeset.ChangesetTimestamp.Date][fileName];
-            dailyCodeChurn.Timestamp = changeset.ChangesetTimestamp.Date.ToString(DailyCodeChurn.DATE_FORMAT);
+            dailyCodeChurn.Timestamp = changeset.ChangesetTimestamp.Date.ToString(DailyCodeChurn.DATE_FORMAT, CultureInfo.InvariantCulture);
             dailyCodeChurn.FileName = fileName;
             return dailyCodeChurn;
         }

--- a/src/vcsparser.core/DailyCodeChurnProcessor.cs
+++ b/src/vcsparser.core/DailyCodeChurnProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -70,7 +71,7 @@ namespace vcsparser.core
             {
                 dict.Add(key, new AggregatedDailyCodeChurn()
                 {
-                    Timestamp = key.ToString(AggregatedDailyCodeChurn.DATE_FORMAT)
+                    Timestamp = key.ToString(AggregatedDailyCodeChurn.DATE_FORMAT, CultureInfo.InvariantCulture)
                 });
             }
 


### PR DESCRIPTION
We need to specify CultureInfo when dealing with dates. So everything behaves the same with different cultures. We will use CultureInfo.Invariant. 

Without `CultureInfo.InvariantCulture` char '\' in `DATE_FORMAT` is formatted in current culture.

https://stackoverflow.com/a/31185798
